### PR TITLE
Removes unnecessary generics from the `Prompt` trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ struct CustomConfirm {
     value: bool,
 }
 
-impl<W: std::io::Write> Prompt<W> for CustomConfirm {
+impl Prompt for CustomConfirm {
     type Output = bool;
 
     // TODO
@@ -316,7 +316,7 @@ use promptuity::{Prompt, PromptState};
 
 // ...
 
-impl<W: std::io::Write> Prompt<W> for CustomConfirm {
+impl Prompt for CustomConfirm {
     // ...
 
     fn handle(&mut self, code: KeyCode, modifiers: KeyModifiers) -> PromptState {
@@ -353,7 +353,7 @@ use promptuity::{Prompt, PromptState, RenderPayload};
 
 // ...
 
-impl<W: std::io::Write> Prompt<W> for CustomConfirm {
+impl Prompt for CustomConfirm {
     // ...
 
     fn render(&mut self, state: &PromptState) -> Result<RenderPayload, String> {
@@ -386,7 +386,7 @@ This is the final step in constructing a custom prompt.
 Implement the [`Prompt::submit`](https://docs.rs/promptuity/latest/promptuity/trait.Prompt.html#tymethod.submit) method, which returns the final value for the received key input.
 
 ```rust
-impl<W: std::io::Write> Prompt<W> for CustomConfirm {
+impl Prompt for CustomConfirm {
     // ...
 
     fn submit(&mut self) -> Self::Output {

--- a/examples/autocomplete.rs
+++ b/examples/autocomplete.rs
@@ -61,7 +61,7 @@ impl AsMut<Autocomplete> for Autocomplete {
     }
 }
 
-impl<W: std::io::Write> Prompt<W> for Autocomplete {
+impl Prompt for Autocomplete {
     type Output = String;
 
     fn setup(&mut self) -> Result<(), Error> {

--- a/examples/extend_prompt.rs
+++ b/examples/extend_prompt.rs
@@ -21,7 +21,7 @@ impl AsMut<ExtendedConfirm> for ExtendedConfirm {
     }
 }
 
-impl<W: std::io::Write> Prompt<W> for ExtendedConfirm {
+impl Prompt for ExtendedConfirm {
     type Output = bool;
 
     fn handle(
@@ -32,28 +32,28 @@ impl<W: std::io::Write> Prompt<W> for ExtendedConfirm {
         match (code, modifiers) {
             (KeyCode::Left, KeyModifiers::NONE) => {
                 // forward to `y` key
-                Prompt::<W>::handle(&mut self.original, KeyCode::Char('y'), KeyModifiers::NONE)
+                Prompt::handle(&mut self.original, KeyCode::Char('y'), KeyModifiers::NONE)
             }
             (KeyCode::Right, KeyModifiers::NONE) => {
                 // forward to `n` key
-                Prompt::<W>::handle(&mut self.original, KeyCode::Char('n'), KeyModifiers::NONE)
+                Prompt::handle(&mut self.original, KeyCode::Char('n'), KeyModifiers::NONE)
             }
             _ => {
                 // forward to original handler
-                Prompt::<W>::handle(&mut self.original, code, modifiers)
+                Prompt::handle(&mut self.original, code, modifiers)
             }
         }
     }
 
     fn submit(&mut self) -> Self::Output {
-        Prompt::<W>::submit(&mut self.original)
+        Prompt::submit(&mut self.original)
     }
 
     fn render(
         &mut self,
         state: &promptuity::PromptState,
     ) -> Result<promptuity::RenderPayload, String> {
-        Prompt::<W>::render(&mut self.original, state)
+        Prompt::render(&mut self.original, state)
     }
 }
 

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -390,7 +390,7 @@ impl RenderPayload {
 }
 
 /// A trait representing the behavior of a prompt.
-pub trait Prompt<W: std::io::Write> {
+pub trait Prompt {
     /// The type returned as a result by the prompt.
     type Output;
 
@@ -575,7 +575,7 @@ impl<'a, W: std::io::Write> Promptuity<'a, W> {
     }
 
     /// Executes the specified prompt and returns the input result.
-    pub fn prompt<O>(&mut self, prompt: &mut dyn Prompt<W, Output = O>) -> Result<O, Error> {
+    pub fn prompt<O>(&mut self, prompt: &mut dyn Prompt<Output = O>) -> Result<O, Error> {
         prompt.setup()?;
 
         self.state = PromptState::Active;
@@ -616,7 +616,7 @@ impl<'a, W: std::io::Write> Promptuity<'a, W> {
         }
     }
 
-    fn render<O>(&mut self, prompt: &mut dyn Prompt<W, Output = O>) -> Result<(), Error> {
+    fn render<O>(&mut self, prompt: &mut dyn Prompt<Output = O>) -> Result<(), Error> {
         let res = prompt.render(&self.state).map_err(Error::Prompt)?;
 
         self.theme.render(

--- a/src/prompts/confirm.rs
+++ b/src/prompts/confirm.rs
@@ -130,7 +130,7 @@ impl AsMut<Confirm> for Confirm {
     }
 }
 
-impl<W: std::io::Write> Prompt<W> for Confirm {
+impl Prompt for Confirm {
     type Output = bool;
 
     fn handle(&mut self, code: KeyCode, modifiers: KeyModifiers) -> PromptState {
@@ -190,28 +190,24 @@ mod tests {
 
     test_prompt!(
         test_hint,
-        Confirm,
         Confirm::new("test message").with_hint("hint message"),
         vec![]
     );
 
     test_prompt!(
         test_default_enter,
-        Confirm,
         Confirm::new("test message").as_mut(),
         vec![(KeyCode::Enter, KeyModifiers::NONE)]
     );
 
     test_prompt!(
         test_default_yes,
-        Confirm,
         Confirm::new("test message").with_default(true),
         vec![(KeyCode::Enter, KeyModifiers::NONE)]
     );
 
     test_prompt!(
         test_move,
-        Confirm,
         Confirm::new("test message").as_mut(),
         vec![
             (KeyCode::Left, KeyModifiers::NONE),
@@ -228,28 +224,24 @@ mod tests {
 
     test_prompt!(
         test_direct_lower_yes,
-        Confirm,
         Confirm::new("test message").with_default(false),
         vec![(KeyCode::Char('y'), KeyModifiers::NONE)]
     );
 
     test_prompt!(
         test_direct_upper_yes,
-        Confirm,
         Confirm::new("test message").with_default(false),
         vec![(KeyCode::Char('Y'), KeyModifiers::NONE)]
     );
 
     test_prompt!(
         test_direct_lower_no,
-        Confirm,
         Confirm::new("test message").with_default(true),
         vec![(KeyCode::Char('n'), KeyModifiers::NONE)]
     );
 
     test_prompt!(
         test_direct_upper_no,
-        Confirm,
         Confirm::new("test message").with_default(true),
         vec![(KeyCode::Char('N'), KeyModifiers::NONE)]
     );

--- a/src/prompts/input.rs
+++ b/src/prompts/input.rs
@@ -126,7 +126,7 @@ impl AsMut<Input> for Input {
     }
 }
 
-impl<W: std::io::Write> Prompt<W> for Input {
+impl Prompt for Input {
     type Output = String;
 
     fn handle(&mut self, code: KeyCode, modifiers: KeyModifiers) -> PromptState {
@@ -210,21 +210,18 @@ mod tests {
 
     test_prompt!(
         test_hint,
-        Input,
         Input::new("test message").with_hint("hint message"),
         vec![]
     );
 
     test_prompt!(
         test_placeholder,
-        Input,
         Input::new("test message").with_placeholder("placeholder message"),
         vec![]
     );
 
     test_prompt!(
         test_default,
-        Input,
         Input::new("test message").as_mut(),
         vec![
             (KeyCode::Char('a'), KeyModifiers::NONE),
@@ -239,21 +236,18 @@ mod tests {
 
     test_prompt!(
         test_required_error,
-        Input,
         Input::new("test message").as_mut(),
         vec![(KeyCode::Enter, KeyModifiers::NONE)]
     );
 
     test_prompt!(
         test_non_required_empty_submit,
-        Input,
         Input::new("test message").with_required(false),
         vec![(KeyCode::Enter, KeyModifiers::NONE)]
     );
 
     test_prompt!(
         test_move,
-        Input,
         Input::new("test message").with_default("abcdef"),
         vec![
             (KeyCode::Left, KeyModifiers::NONE),
@@ -268,7 +262,6 @@ mod tests {
 
     test_prompt!(
         test_editing,
-        Input,
         Input::new("test message").with_default("abcdef"),
         vec![
             (KeyCode::Backspace, KeyModifiers::NONE),
@@ -298,7 +291,6 @@ mod tests {
 
     test_prompt!(
         test_validation,
-        Input,
         Input::new("test message").with_validator(|v: &String| {
             if v.as_str() == "abc" {
                 Err("Error Message".into())

--- a/src/prompts/multi_select.rs
+++ b/src/prompts/multi_select.rs
@@ -269,7 +269,7 @@ impl<T: Default + Clone> AsMut<MultiSelect<T>> for MultiSelect<T> {
     }
 }
 
-impl<T: Default + Clone, W: std::io::Write> Prompt<W> for MultiSelect<T> {
+impl<T: Default + Clone> Prompt for MultiSelect<T> {
     type Output = Vec<T>;
 
     fn setup(&mut self) -> Result<(), Error> {
@@ -415,27 +415,24 @@ mod tests {
 
     test_prompt!(
         test_hint,
-        MultiSelect<String>,
         MultiSelect::new("test message", options!(3)).with_hint("hint message"),
         vec![]
     );
 
     test_prompt!(
         test_10_items_with_5_page_size,
-        MultiSelect<String>,
         MultiSelect::new("test message", options!(10)).with_page_size(5),
         vec![]
     );
 
     test_prompt!(
         test_option_hint,
-        MultiSelect<String>,
         MultiSelect::new(
             "test message",
             vec![
-                MultiSelectOption::new("Value1", "value1".into()).with_hint("hint1"),
-                MultiSelectOption::new("Value2", "value2".into()),
-                MultiSelectOption::new("Value3", "value3".into()).with_hint("hint3"),
+                MultiSelectOption::new("Value1", "value1".to_string()).with_hint("hint1"),
+                MultiSelectOption::new("Value2", "value2".to_string()),
+                MultiSelectOption::new("Value3", "value3".to_string()).with_hint("hint3"),
             ]
         )
         .with_page_size(5),
@@ -444,7 +441,6 @@ mod tests {
 
     test_prompt!(
         test_move,
-        MultiSelect<String>,
         MultiSelect::new("test message", options!(10)).with_page_size(5),
         vec![
             (KeyCode::Char('j'), KeyModifiers::NONE),
@@ -476,7 +472,6 @@ mod tests {
 
     test_prompt!(
         test_select_2_and_5,
-        MultiSelect<String>,
         MultiSelect::new("test message", options!(10)).with_page_size(5),
         vec![
             (KeyCode::Down, KeyModifiers::NONE),
@@ -491,7 +486,6 @@ mod tests {
 
     test_prompt!(
         test_select_all_and_inverse,
-        MultiSelect<String>,
         MultiSelect::new("test message", options!(5)).as_mut(),
         vec![
             (KeyCode::Char('a'), KeyModifiers::NONE),
@@ -507,21 +501,18 @@ mod tests {
 
     test_prompt!(
         test_required_error,
-        MultiSelect<String>,
         MultiSelect::new("test message", options!(5)).with_required(true),
         vec![(KeyCode::Enter, KeyModifiers::NONE)]
     );
 
     test_prompt!(
         test_non_required_empty_submit,
-        MultiSelect<String>,
         MultiSelect::new("test message", options!(5)).with_required(false),
         vec![(KeyCode::Enter, KeyModifiers::NONE)]
     );
 
     test_prompt!(
         test_min_error,
-        MultiSelect<String>,
         MultiSelect::new("test message", options!(5)).with_min(2),
         vec![
             (KeyCode::Enter, KeyModifiers::NONE),
@@ -535,7 +526,6 @@ mod tests {
 
     test_prompt!(
         test_max_error,
-        MultiSelect<String>,
         MultiSelect::new("test message", options!(5)).with_max(3),
         vec![
             (KeyCode::Enter, KeyModifiers::NONE),

--- a/src/prompts/number.rs
+++ b/src/prompts/number.rs
@@ -200,7 +200,7 @@ impl AsMut<Number> for Number {
     }
 }
 
-impl<W: std::io::Write> Prompt<W> for Number {
+impl Prompt for Number {
     type Output = isize;
 
     fn setup(&mut self) -> Result<(), crate::Error> {
@@ -311,42 +311,36 @@ mod tests {
 
     test_prompt!(
         test_hint,
-        Number,
         Number::new("test message").with_hint("hint message"),
         vec![]
     );
 
     test_prompt!(
         test_placeholder,
-        Number,
         Number::new("test message").with_placeholder("placeholder message"),
         vec![]
     );
 
     test_prompt!(
         test_default,
-        Number,
         Number::new("test message").with_default(100),
         vec![]
     );
 
     test_prompt!(
         test_required_error,
-        Number,
         Number::new("test message").with_required(true),
         vec![(KeyCode::Enter, KeyModifiers::NONE)]
     );
 
     test_prompt!(
         test_non_required_empty_submit,
-        Number,
         Number::new("test message").with_required(false),
         vec![(KeyCode::Enter, KeyModifiers::NONE)]
     );
 
     test_prompt!(
         test_number_input,
-        Number,
         Number::new("test message").as_mut(),
         vec![
             (KeyCode::Char('1'), KeyModifiers::NONE),
@@ -370,7 +364,6 @@ mod tests {
 
     test_prompt!(
         test_invalid_format,
-        Number,
         Number::new("test message").as_mut(),
         vec![
             (KeyCode::Char('-'), KeyModifiers::NONE),
@@ -380,7 +373,6 @@ mod tests {
 
     test_prompt!(
         test_min_value,
-        Number,
         Number::new("test message").with_min(2),
         vec![
             (KeyCode::Char('1'), KeyModifiers::NONE),
@@ -393,7 +385,6 @@ mod tests {
 
     test_prompt!(
         test_max_value,
-        Number,
         Number::new("test message").with_max(2),
         vec![
             (KeyCode::Char('3'), KeyModifiers::NONE),
@@ -406,7 +397,6 @@ mod tests {
 
     test_prompt!(
         test_increment_decrement,
-        Number,
         Number::new("test message").with_min(2).with_max(4),
         vec![
             (KeyCode::Char('1'), KeyModifiers::NONE),

--- a/src/prompts/password.rs
+++ b/src/prompts/password.rs
@@ -119,7 +119,7 @@ impl AsMut<Password> for Password {
     }
 }
 
-impl<W: std::io::Write> Prompt<W> for Password {
+impl Prompt for Password {
     type Output = String;
 
     fn handle(
@@ -210,28 +210,24 @@ mod tests {
 
     test_prompt!(
         test_hint,
-        Password,
         Password::new("test message").with_hint("hint message"),
         vec![]
     );
 
     test_prompt!(
         test_required_error,
-        Password,
         Password::new("test message").with_required(true),
         vec![(KeyCode::Enter, KeyModifiers::NONE)]
     );
 
     test_prompt!(
         test_non_required_empty_submit,
-        Password,
         Password::new("test message").with_required(false),
         vec![(KeyCode::Enter, KeyModifiers::NONE)]
     );
 
     test_prompt!(
         test_input,
-        Password,
         Password::new("test message").as_mut(),
         vec![
             (KeyCode::Char('a'), KeyModifiers::NONE),
@@ -244,7 +240,6 @@ mod tests {
 
     test_prompt!(
         test_editing,
-        Password,
         Password::new("test message").as_mut(),
         vec![
             (KeyCode::Char('a'), KeyModifiers::NONE),
@@ -280,7 +275,6 @@ mod tests {
 
     test_prompt!(
         test_custom_mask,
-        Password,
         Password::new("test message").with_mask('∙'),
         vec![
             (KeyCode::Char('a'), KeyModifiers::NONE),

--- a/src/prompts/select.rs
+++ b/src/prompts/select.rs
@@ -176,7 +176,7 @@ impl<T: Default + Clone> AsMut<Select<T>> for Select<T> {
     }
 }
 
-impl<T: Default + Clone, W: std::io::Write> Prompt<W> for Select<T> {
+impl<T: Default + Clone> Prompt for Select<T> {
     type Output = T;
 
     fn setup(&mut self) -> Result<(), Error> {
@@ -269,34 +269,30 @@ mod tests {
 
     test_prompt!(
         test_hint,
-        Select<String>,
         Select::new("test message", options!(3)).with_hint("hint message"),
         vec![]
     );
 
     test_prompt!(
         test_10_items,
-        Select<String>,
         Select::new("test message", options!(10)).as_mut(),
         vec![]
     );
 
     test_prompt!(
         test_10_items_with_5_page_size,
-        Select<String>,
         Select::new("test message", options!(10)).with_page_size(5),
         vec![]
     );
 
     test_prompt!(
         test_option_hint,
-        Select<String>,
         Select::new(
             "test message",
             vec![
-                SelectOption::new("Value1", "value1".into()).with_hint("hint1"),
-                SelectOption::new("Value2", "value2".into()),
-                SelectOption::new("Value3", "value3".into()).with_hint("hint3"),
+                SelectOption::new("Value1", "value1".to_string()).with_hint("hint1"),
+                SelectOption::new("Value2", "value2".to_string()),
+                SelectOption::new("Value3", "value3".to_string()).with_hint("hint3"),
             ]
         )
         .with_page_size(5),
@@ -305,7 +301,6 @@ mod tests {
 
     test_prompt!(
         test_move,
-        Select<String>,
         Select::new("test message", options!(10)).with_page_size(5),
         vec![
             (KeyCode::Char('j'), KeyModifiers::NONE),
@@ -337,7 +332,6 @@ mod tests {
 
     test_prompt!(
         test_select_5,
-        Select<String>,
         Select::new("test message", options!(10)).as_mut(),
         vec![
             (KeyCode::Char('j'), KeyModifiers::NONE),

--- a/tests/themes.rs
+++ b/tests/themes.rs
@@ -24,7 +24,7 @@ struct DummyPrompt {
     placeholder: bool,
 }
 
-impl<W: std::io::Write> Prompt<W> for DummyPrompt {
+impl Prompt for DummyPrompt {
     type Output = ();
 
     fn handle(&mut self, code: KeyCode, modifiers: KeyModifiers) -> promptuity::PromptState {


### PR DESCRIPTION
BREAKING CHANGE: It used to be an interface that accepts `std::io::Write`, but this was an unnecessary generic added in the initial implementation. It has been removed after refactoring.